### PR TITLE
update gitpod.yml to use full-vnc image

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,4 @@
+image: gitpod/workspace-full-vnc
 tasks:
   - init: sudo apt-get update && sudo apt-get install -y mesa-utils freeglut3-dev libgl1 libxkbcommon-x11-0 x11-xserver-utils && export PIP_USER=false && python -m pip install --upgrade pip && pip install poetry && poetry install && poetry shell
     command: pytest


### PR DESCRIPTION
This rounds-out the incomplete earlier fix for making the tests pass without the dockerfile.

Feel free to test this out at: https://gitpod.io/#https://github.com/koushik-ms/slicereg/tree/exp-dockerfile
